### PR TITLE
Fixed ProfileView looping bug

### DIFF
--- a/src/actions/actionCreators.js
+++ b/src/actions/actionCreators.js
@@ -294,8 +294,8 @@ export const getProfile = user_id => dispatch => {
 }
 
 // for Modal:
-export const displayNotificationModal = (message, buttonLink) => dispatch => {
-  dispatch({ type: types.DISPLAY_NOTIFICATION_MODAL, payload: ({ message, buttonLink })});
+export const displayNotificationModal = (message, buttonLink, disableContinue = false) => dispatch => {
+  dispatch({ type: types.DISPLAY_NOTIFICATION_MODAL, payload: ({ message, buttonLink, disableContinue })});
 }
 
 export const displayLikeModal = (message, buttonLink) => dispatch => {

--- a/src/actions/actionCreators.js
+++ b/src/actions/actionCreators.js
@@ -295,17 +295,17 @@ export const getProfile = user_id => dispatch => {
 
 // for Modal:
 export const displayNotificationModal = (message, buttonLink, disableContinue = false) => dispatch => {
-  dispatch({ type: types.DISPLAY_NOTIFICATION_MODAL, payload: ({ message, buttonLink, disableContinue })});
+  dispatch({ type: types.DISPLAY_NOTIFICATION_MODAL, payload: ({ message, buttonLink, disableContinue }) });
 }
 
 export const displayLikeModal = (message, buttonLink) => dispatch => {
-  dispatch({ type: types.DISPLAY_LIKE_MODAL, payload: ({ message, buttonLink })});
+  dispatch({ type: types.DISPLAY_LIKE_MODAL, payload: ({ message, buttonLink }) });
 
   setTimeout(() => dispatch({ type: types.DISMISS_MODAL }), 3001);
 }
 
-export const displayErrorModal = message => dispatch => {
-  dispatch({ type: types.DISPLAY_ERROR_MODAL, payload: message });
+export const displayErrorModal = (message, buttonLink) => dispatch => {
+  dispatch({ type: types.DISPLAY_ERROR_MODAL, payload: ({ message, buttonLink }) });
 }
 
 export const dismissModal = () => dispatch => {

--- a/src/components/createRecipe/recipeForm/Step3.jsx
+++ b/src/components/createRecipe/recipeForm/Step3.jsx
@@ -64,6 +64,7 @@ function Step3(props) {
   };
 
   const onSubmit = e => {
+    debugger
     e.preventDefault();
     addRecipeIngredientsToBody(ingredientsArray);
     goForward(e);
@@ -100,7 +101,7 @@ function Step3(props) {
   };
 
   return (
-    <form onSubmit={onSubmit}>
+    <form>
       <Section3>
         <NavigationSection1>
           <Fab
@@ -119,7 +120,7 @@ function Step3(props) {
               outline: "none"
             }}
           >
-            <CheckIcon className="check-icon" onClick={goForward} cgit="true" />
+            <CheckIcon className="check-icon" onClick={onSubmit} cgit="true" />
           </Fab>
         </NavigationSection1>
         <Addtitle>

--- a/src/components/createRecipe/recipeForm/Step3.jsx
+++ b/src/components/createRecipe/recipeForm/Step3.jsx
@@ -64,7 +64,6 @@ function Step3(props) {
   };
 
   const onSubmit = e => {
-    debugger
     e.preventDefault();
     addRecipeIngredientsToBody(ingredientsArray);
     goForward(e);

--- a/src/components/createRecipe/recipeForm/Step5.jsx
+++ b/src/components/createRecipe/recipeForm/Step5.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import * as dispatchers from "../../../actions/actionCreators";
 
@@ -21,7 +21,9 @@ function Step5(props) {
     images,
     recipe_ingredients,
     instructions,
-    goBackward
+    goBackward,
+    displayNotificationModal,
+    data // From newlyAddedRecipe
   } = props;
 
   const submitRecipe = () => {
@@ -35,6 +37,12 @@ function Step5(props) {
     };
     postRecipe(body);
   };
+
+  useEffect(() => {
+    if (data.id) {
+      displayNotificationModal("Recipe successfully created!", `/recipes/${data.id}`)
+    }
+  }, [data, displayNotificationModal]);
 
   const goBack = e => {
     goBackward();
@@ -77,4 +85,7 @@ function Step5(props) {
 }
 
 
-export default connect(state => state.newRecipe, dispatchers)(Step5);
+export default connect(state => ({
+  ...state.newRecipe,
+  ...state.newlyAddedRecipe,
+}), dispatchers)(Step5);

--- a/src/components/createRecipe/recipeForm/Step5.jsx
+++ b/src/components/createRecipe/recipeForm/Step5.jsx
@@ -25,7 +25,6 @@ function Step5(props) {
     displayNotificationModal,
     displayErrorModal,
     data, // From newlyAddedRecipe
-    error // From newlyAddedRecipe
   } = props;
 
   const submitRecipe = () => {
@@ -41,7 +40,6 @@ function Step5(props) {
   };
 
   useEffect(() => {
-    console.log(data);
     if (data.id) {
       displayNotificationModal("Recipe successfully created!", `/recipes/${data.id}`, true);
     } else {

--- a/src/components/createRecipe/recipeForm/Step5.jsx
+++ b/src/components/createRecipe/recipeForm/Step5.jsx
@@ -23,7 +23,9 @@ function Step5(props) {
     instructions,
     goBackward,
     displayNotificationModal,
-    data // From newlyAddedRecipe
+    displayErrorModal,
+    data, // From newlyAddedRecipe
+    error // From newlyAddedRecipe
   } = props;
 
   const submitRecipe = () => {
@@ -39,10 +41,13 @@ function Step5(props) {
   };
 
   useEffect(() => {
+    console.log(data);
     if (data.id) {
       displayNotificationModal("Recipe successfully created!", `/recipes/${data.id}`, true);
+    } else {
+      displayErrorModal("There was a problem creating the recipe. Please try again.", "/profile");
     }
-  }, [data, displayNotificationModal]);
+  }, [data, displayErrorModal, displayNotificationModal]);
 
   const goBack = e => {
     goBackward();

--- a/src/components/createRecipe/recipeForm/Step5.jsx
+++ b/src/components/createRecipe/recipeForm/Step5.jsx
@@ -40,7 +40,7 @@ function Step5(props) {
 
   useEffect(() => {
     if (data.id) {
-      displayNotificationModal("Recipe successfully created!", `/recipes/${data.id}`)
+      displayNotificationModal("Recipe successfully created!", `/recipes/${data.id}`, true);
     }
   }, [data, displayNotificationModal]);
 

--- a/src/components/notification/modal/Modal.jsx
+++ b/src/components/notification/modal/Modal.jsx
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import * as actionCreators from "../../../actions/actionCreators";
 
 export function Modal(props) {
-  const { modalType, message, buttonLink, isDisplaying, dismissModal } = props;
+  const { modalType, message, buttonLink, disableContinue, isDisplaying, dismissModal } = props;
   
   // const { displayNotificationModal, displayErrorModal, displayLikeModal } = props;
   // ^For testing purposes!
@@ -26,7 +26,11 @@ export function Modal(props) {
                 <div className="button-div" id="view" onClick={dismissModal}>
                   <Link to={buttonLink}>VIEW</Link>
                 </div>
-                <div className="button-div" id="continue" onClick={dismissModal}>CONTINUE</div>
+                {
+                  disableContinue ?
+                  null :
+                  <div className="button-div" id="continue" onClick={dismissModal}>CONTINUE</div>
+                }
               </> :
             modalType === "like" ?
               <div className="button-div" id="view" onClick={dismissModal}>

--- a/src/components/profile/profileView/ProfileView.jsx
+++ b/src/components/profile/profileView/ProfileView.jsx
@@ -44,9 +44,9 @@ export function ProfileView(props) {
     getProfile(user_id);
     getUserLikes(user_id)
   }, [getProfile, getUserLikes, user_id]);
-  // Problem: This hook, when conditional on user_likes changing, was stuck in a loop. But how else to make sure the Forked Recipe
+  // Problem: This hook, when conditional on user_recipes changing, was stuck in a loop. But how else to make sure the Forked Recipe
   // and Forks counts (i.e. the profile) update when a recipe is (un)liked?
-  // Tentative solution: Remove user_likes from the above dependency array, and make clicking the recipe container call
+  // Tentative solution: Remove user_recipes from the above dependency array, and make clicking the recipe container call
   // getProfile(user_id) at a delay! It's imperfect... but removes the looping!
 
   const getDelayedProfile = () => {

--- a/src/components/profile/profileView/ProfileView.jsx
+++ b/src/components/profile/profileView/ProfileView.jsx
@@ -43,7 +43,15 @@ export function ProfileView(props) {
   useEffect(() => {
     getProfile(user_id);
     getUserLikes(user_id)
-  }, [getProfile, getUserLikes, user_id, user_recipes]);
+  }, [getProfile, getUserLikes, user_id]);
+  // Problem: This hook, when conditional on user_likes changing, was stuck in a loop. But how else to make sure the Forked Recipe
+  // and Forks counts (i.e. the profile) update when a recipe is (un)liked?
+  // Tentative solution: Remove user_likes from the above dependency array, and make clicking the recipe container call
+  // getProfile(user_id) at a delay! It's imperfect... but removes the looping!
+
+  const getDelayedProfile = () => {
+    setTimeout(() => getProfile(user_id), 1000);
+  };
 
   useEffect(() => {
     setSanitisedUserRecipes(sanitiseRecipes(user_recipes));
@@ -142,7 +150,7 @@ export function ProfileView(props) {
                 <p>Recipes you create appear here!</p>
               </div>
             ) : (
-              <div className="container">
+              <div className="container" onClick={getDelayedProfile}>
                 {sanitisedUserRecipes.map(recipe => (
                   <Recipe
                     key={recipe.id}
@@ -159,7 +167,7 @@ export function ProfileView(props) {
                   <p>Recipes you 'fork' appear here!</p>
                 </div>
               ) : (
-                <div className="container">
+                <div className="container" onClick={getDelayedProfile}>
                   {sanitisedLikedRecipes.map(recipe => (
                     <Recipe
                       key={recipe.id}

--- a/src/components/profile/profileView/ProfileView.jsx
+++ b/src/components/profile/profileView/ProfileView.jsx
@@ -43,7 +43,15 @@ export function ProfileView(props) {
   useEffect(() => {
     getProfile(user_id);
     getUserLikes(user_id)
-  }, [getProfile, getUserLikes, user_id, user_recipes]);
+  }, [getProfile, getUserLikes, user_id]);
+  // Problem: This hook, when conditional on user_recipes changing, was stuck in a loop. But how else to make sure the Forked Recipe
+  // and Forks counts (i.e. the profile) update when a recipe is (un)liked?
+  // Tentative solution: Remove user_recipes from the above dependency array, and make clicking the recipe container call
+  // getProfile(user_id) at a delay! It's imperfect... but removes the looping!
+
+  const getDelayedProfile = () => {
+    setTimeout(() => getProfile(user_id), 1000);
+  };
 
   useEffect(() => {
     setSanitisedUserRecipes(sanitiseRecipes(user_recipes));
@@ -142,7 +150,7 @@ export function ProfileView(props) {
                 <p>Recipes you create appear here!</p>
               </div>
             ) : (
-              <div className="container">
+              <div className="container" onClick={getDelayedProfile}>
                 {sanitisedUserRecipes.map(recipe => (
                   <Recipe
                     key={recipe.id}
@@ -159,7 +167,7 @@ export function ProfileView(props) {
                   <p>Recipes you 'fork' appear here!</p>
                 </div>
               ) : (
-                <div className="container">
+                <div className="container" onClick={getDelayedProfile}>
                   {sanitisedLikedRecipes.map(recipe => (
                     <Recipe
                       key={recipe.id}

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -736,7 +736,8 @@ const initialModalState = {
   modalType: "notification",
   message: "",
   buttonLink: "/login",
-  isDisplaying: false
+  isDisplaying: false,
+  displayContinue: false
 };
 export function modalReducer(state = initialModalState, action) {
   switch (action.type) {

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -756,9 +756,8 @@ export function modalReducer(state = initialModalState, action) {
     case types.DISPLAY_ERROR_MODAL:
       return {
         modalType: "error",
-        message: action.payload,
-        buttonLink: "/login",
-        isDisplaying: true
+        isDisplaying: true,
+        ...action.payload
       };
     case types.DISMISS_MODAL:
       return initialModalState;

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -532,7 +532,7 @@ export function newRecipeReducer(state = initialBody, action) {
 }
 
 const initialNewlyAddedRecipe = {
-  data: [],
+  data: {},
   error: ""
 };
 

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -10,6 +10,7 @@ const monsterReducer = combineReducers({
   editIngredient: reducers.editIngredientReducer,
   editInstruction: reducers.editInstructionReducer,
   newRecipe : reducers.newRecipeReducer,
+  newlyAddedRecipe : reducers.newlyAddedRecipe,
   onboard : reducers.onBoardingReducer,
   recipes : reducers.recipeViewReducer,
   singleRecipe: reducers.singleRecipeReducer,


### PR DESCRIPTION
# Description

As I wrote in my comment: 

`Problem: This hook, when conditional on user_likes changing, was stuck in a loop. But how else to make sure the Forked Recipe and Forks counts (i.e. the profile) update when a recipe is (un)liked?
Tentative solution: Remove user_likes from the above dependency array, and make clicking the recipe container call getProfile(user_id) at a delay! It's imperfect... but removes the looping!`

(P.S. Apologies about the funky commit history. Had some minor Git issues! :P )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Console and Redux Dev Tools.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [x] I have run the app using my feature and ensured that no functionality is broken
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
